### PR TITLE
Add 'npm run-script' support to Cake.Npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "hello": "echo \"Hello from cake-npm!\" ",
+    "arguments": "echo Arguments are appended onto the script command like so: "
   },
   "author": "",
   "license": "MIT"

--- a/src/Cake.Npm.Tests/Cake.Npm.Tests.csproj
+++ b/src/Cake.Npm.Tests/Cake.Npm.Tests.csproj
@@ -71,6 +71,7 @@
   <ItemGroup>
     <Compile Include="NpmRunnerFixture.cs" />
     <Compile Include="NpmRunnerTests.cs" />
+    <Compile Include="NpmRunScriptTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Cake.Npm.Tests/NpmRunScriptTests.cs
+++ b/src/Cake.Npm.Tests/NpmRunScriptTests.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Shouldly;
+using Cake.Testing.Fixtures;
+using Xunit;
+
+namespace Cake.Npm.Tests
+{
+	public class NpmRunScriptTests
+	{
+		private readonly NpmRunScriptFixture _fixture;
+		public NpmRunScriptTests()
+		{
+			_fixture = new NpmRunScriptFixture();
+		}
+
+		[Fact]
+		public void Not_Setting_ScriptName_Should_Fail()
+		{
+			_fixture.ScriptName = "";
+			Assert.Throws<ArgumentNullException>(() => _fixture.Run());
+		}
+
+		[Fact]
+		public void Setting_Force_Should_Throw_Exception()
+		{
+			_fixture.RunScriptSettings = s => s.WithForce();
+			Assert.Throws<NotImplementedException>(() => _fixture.Run());
+		}
+
+		[Fact]
+		public void Not_Including_Args_Should_Produce_Empty_Command()
+		{
+			var result = _fixture.Run();
+			result.Args.ShouldBe("run script");
+		}
+
+		[Fact]
+		public void Including_Args_Should_Add_Delimiter()
+		{
+			_fixture.RunScriptSettings = s => s.WithArgument("-param");
+
+			var result = _fixture.Run();
+			result.Args.ShouldBe("run script -- -param");
+		}
+
+		[Fact]
+		public void Including_Multiple_Args_Should_Include_All()
+		{
+			_fixture.RunScriptSettings = s => s.WithArgument("-param").WithArgument("-default");
+			var result = _fixture.Run();
+			result.Args.ShouldBe("run script -- -param -default");
+		}
+
+		[Fact]
+		public void Run_Named_Script_Should_Run_Correct_Script()
+		{
+			_fixture.ScriptName = "build";
+			var result = _fixture.Run();
+			result.Args.ShouldBe("run build");
+		}
+
+		[Fact]
+		public void Named_Script_Should_Insert_Args_Correctly()
+		{
+			_fixture.ScriptName = "build";
+			_fixture.RunScriptSettings = s => s.WithArgument("-param").WithArgument("-default");
+			var result = _fixture.Run();
+			result.Args.ShouldBe("run build -- -param -default");
+		}
+	}
+}

--- a/src/Cake.Npm.Tests/NpmRunScriptTests.cs
+++ b/src/Cake.Npm.Tests/NpmRunScriptTests.cs
@@ -31,7 +31,7 @@ namespace Cake.Npm.Tests
 		public void Not_Including_Args_Should_Produce_Empty_Command()
 		{
 			var result = _fixture.Run();
-			result.Args.ShouldBe("run script");
+			result.Args.ShouldBe("run-script build");
 		}
 
 		[Fact]
@@ -40,7 +40,7 @@ namespace Cake.Npm.Tests
 			_fixture.RunScriptSettings = s => s.WithArgument("-param");
 
 			var result = _fixture.Run();
-			result.Args.ShouldBe("run script -- -param");
+			result.Args.ShouldBe("run-script build -- -param");
 		}
 
 		[Fact]
@@ -48,15 +48,15 @@ namespace Cake.Npm.Tests
 		{
 			_fixture.RunScriptSettings = s => s.WithArgument("-param").WithArgument("-default");
 			var result = _fixture.Run();
-			result.Args.ShouldBe("run script -- -param -default");
+			result.Args.ShouldBe("run-script build -- -param -default");
 		}
 
 		[Fact]
 		public void Run_Named_Script_Should_Run_Correct_Script()
 		{
-			_fixture.ScriptName = "build";
+			_fixture.ScriptName = "server";
 			var result = _fixture.Run();
-			result.Args.ShouldBe("run build");
+			result.Args.ShouldBe("run-script server");
 		}
 
 		[Fact]
@@ -65,7 +65,7 @@ namespace Cake.Npm.Tests
 			_fixture.ScriptName = "build";
 			_fixture.RunScriptSettings = s => s.WithArgument("-param").WithArgument("-default");
 			var result = _fixture.Run();
-			result.Args.ShouldBe("run build -- -param -default");
+			result.Args.ShouldBe("run-script build -- -param -default");
 		}
 	}
 }

--- a/src/Cake.Npm.Tests/NpmRunnerFixture.cs
+++ b/src/Cake.Npm.Tests/NpmRunnerFixture.cs
@@ -20,7 +20,7 @@ namespace Cake.Npm.Tests {
 	{
 		internal string ScriptName { get; set; } = string.Empty;
 
-		public NpmRunScriptFixture(string scriptName = "script") : base("npm")
+		public NpmRunScriptFixture(string scriptName = "build") : base("npm")
 		{
 			ScriptName = scriptName;
 		}

--- a/src/Cake.Npm.Tests/NpmRunnerFixture.cs
+++ b/src/Cake.Npm.Tests/NpmRunnerFixture.cs
@@ -8,9 +8,28 @@ namespace Cake.Npm.Tests {
 
 		public Action<NpmInstallSettings> InstallSettings { get; set; }
 
+		
+
 		protected override void RunTool() {
 			var tool = new NpmRunner(FileSystem, Environment, ProcessRunner, Globber);
 			tool.Install(InstallSettings);
+		}
+	}
+
+	public class NpmRunScriptFixture : ToolFixture<NpmRunScriptSettings>
+	{
+		internal string ScriptName { get; set; } = string.Empty;
+
+		public NpmRunScriptFixture(string scriptName = "script") : base("npm")
+		{
+			ScriptName = scriptName;
+		}
+		public Action<NpmRunScriptSettings> RunScriptSettings { get; set; }
+
+		protected override void RunTool()
+		{
+			var tool = new NpmRunner(FileSystem, Environment, ProcessRunner, Globber);
+			tool.RunScript(ScriptName, RunScriptSettings);
 		}
 	}
 }

--- a/src/Cake.Npm/Cake.Npm.csproj
+++ b/src/Cake.Npm/Cake.Npm.csproj
@@ -22,8 +22,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cake.Npm.XML</DocumentationFile>
-    <NoWarn>
-    </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,7 +31,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Cake.Npm.XML</DocumentationFile>
-    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Cake.Core, Version=0.9.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Cake.Npm/Cake.Npm.csproj
+++ b/src/Cake.Npm/Cake.Npm.csproj
@@ -22,7 +22,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cake.Npm.XML</DocumentationFile>
-    <NoWarn>1591</NoWarn>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/Cake.Npm/Cake.Npm.csproj
+++ b/src/Cake.Npm/Cake.Npm.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Cake.Npm.XML</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,6 +32,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Cake.Npm.XML</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Cake.Core, Version=0.9.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -47,6 +49,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="NpmRunScriptSettings.cs" />
     <Compile Include="..\VersionAssemblyInfo.cs">
       <Link>Properties\VersionAssemblyInfo.cs</Link>
     </Compile>

--- a/src/Cake.Npm/NpmRunScriptSettings.cs
+++ b/src/Cake.Npm/NpmRunScriptSettings.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Npm
+{
+	public class NpmRunScriptSettings : NpmRunnerSettings
+	{
+		public IList<string> Arguments { get; set; } = new List<string>();
+
+		public NpmRunScriptSettings() : base("run")
+		{
+			
+		}
+		public NpmRunScriptSettings(string command) : base("run")
+		{
+			ScriptName = command;
+		}
+
+		protected string ScriptName { get; set; } = String.Empty;
+
+		protected override void EvaluateCore(ProcessArgumentBuilder args)
+		{
+			if (Force) throw new NotImplementedException("npm run-script does not support --force flag");
+			if (string.IsNullOrEmpty(ScriptName)) throw new ArgumentNullException(nameof(ScriptName), "Must provide script name!");
+			args.Append(ScriptName);
+			if (Arguments.Any())
+			{
+				args.Append("--");
+				foreach (var arg in Arguments)
+				{
+					args.Append(arg);
+				}
+			}
+			base.EvaluateCore(args);
+		}
+
+		public NpmRunScriptSettings WithArgument(string arg)
+		{
+			Arguments.Add(arg);
+			return this;
+		}
+
+		protected virtual void WithForce(bool force)
+		{
+			
+		}
+	}
+}

--- a/src/Cake.Npm/NpmRunScriptSettings.cs
+++ b/src/Cake.Npm/NpmRunScriptSettings.cs
@@ -8,21 +8,41 @@ using Cake.Core.IO;
 
 namespace Cake.Npm
 {
+	/// <summary>
+	/// npm run-script options
+	/// </summary>
 	public class NpmRunScriptSettings : NpmRunnerSettings
 	{
+		/// <summary>
+		/// Arguments to pass to the target script
+		/// </summary>
 		public IList<string> Arguments { get; set; } = new List<string>();
 
-		public NpmRunScriptSettings() : base("run")
+		/// <summary>
+		/// npm 'run-script' settings
+		/// </summary>
+		public NpmRunScriptSettings() : base("run-script")
 		{
 			
 		}
-		public NpmRunScriptSettings(string command) : base("run")
+		/// <summary>
+		/// npm 'run-script' settings for the named script
+		/// </summary>
+		/// <param name="command">script name to execute</param>
+		public NpmRunScriptSettings(string command) : base("run-script")
 		{
 			ScriptName = command;
 		}
 
-		protected string ScriptName { get; set; } = String.Empty;
+		/// <summary>
+		/// Name of the script to execute as defined in package.json
+		/// </summary>
+		public string ScriptName { get; set; } = string.Empty;
 
+		/// <summary>
+		/// evaluate options
+		/// </summary>
+		/// <param name="args"></param>
 		protected override void EvaluateCore(ProcessArgumentBuilder args)
 		{
 			if (Force) throw new NotImplementedException("npm run-script does not support --force flag");
@@ -39,13 +59,22 @@ namespace Cake.Npm
 			base.EvaluateCore(args);
 		}
 
+		/// <summary>
+		/// adds
+		/// </summary>
+		/// <param name="arg"></param>
+		/// <returns></returns>
 		public NpmRunScriptSettings WithArgument(string arg)
 		{
 			Arguments.Add(arg);
 			return this;
 		}
 
-		protected virtual void WithForce(bool force)
+		/// <summary>
+		/// Unsupported
+		/// </summary>
+		/// <param name="force"></param>
+		protected new void WithForce(bool force)
 		{
 			
 		}

--- a/src/Cake.Npm/NpmRunner.cs
+++ b/src/Cake.Npm/NpmRunner.cs
@@ -6,81 +6,81 @@ using Cake.Core.Tooling;
 
 namespace Cake.Npm
 {
-	/// <summary>
-	/// A wrapper around the Node Npm package manager
-	/// </summary>
-	public class NpmRunner : Tool<NpmRunnerSettings>
-	{
-		/// <summary>
-		/// Initializes a new instance of the <see cref="NpmRunner" /> class.
-		/// </summary>
-		/// <param name="fileSystem">The file system</param>
-		/// <param name="environment">The environment</param>
-		/// <param name="processRunner">The process runner</param>
-		/// <param name="globber">The globber</param>
-		internal NpmRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IGlobber globber) : base(fileSystem, environment, processRunner, globber)
-		{
-		}
-		
-		/// <summary>
-		/// execute 'npm install' with options
-		/// </summary>
-		/// <param name="configure">options when running 'npm install'</param>
-		public void Install(Action<NpmInstallSettings> configure = null)
-		{
-			var settings = new NpmInstallSettings();
-			configure?.Invoke(settings);
+    /// <summary>
+    /// A wrapper around the Node Npm package manager
+    /// </summary>
+    public class NpmRunner : Tool<NpmRunnerSettings>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NpmRunner" /> class.
+        /// </summary>
+        /// <param name="fileSystem">The file system</param>
+        /// <param name="environment">The environment</param>
+        /// <param name="processRunner">The process runner</param>
+        /// <param name="globber">The globber</param>
+        internal NpmRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IGlobber globber) : base(fileSystem, environment, processRunner, globber)
+        {
+        }
+        
+        /// <summary>
+        /// execute 'npm install' with options
+        /// </summary>
+        /// <param name="configure">options when running 'npm install'</param>
+        public void Install(Action<NpmInstallSettings> configure = null)
+        {
+            var settings = new NpmInstallSettings();
+            configure?.Invoke(settings);
 
-			var args = GetNpmInstallArguments(settings);
+            var args = GetNpmInstallArguments(settings);
 
-			Run(settings, args);
-		}
+            Run(settings, args);
+        }
 
-		private ProcessArgumentBuilder GetNpmInstallArguments(NpmInstallSettings settings)
-		{
-			var args = new ProcessArgumentBuilder();
-			settings.Evaluate(args);
-			return args;
-		}
+        private ProcessArgumentBuilder GetNpmInstallArguments(NpmInstallSettings settings)
+        {
+            var args = new ProcessArgumentBuilder();
+            settings.Evaluate(args);
+            return args;
+        }
 
-		/// <summary>
-		/// execute 'npm run'/'npm run-script' with arguments
-		/// </summary>
-		/// <param name="scriptName">name of the </param>
-		/// <param name="configure"></param>
-		public void RunScript(string scriptName, Action<NpmRunScriptSettings> configure = null)
-		{
-			var settings = new NpmRunScriptSettings(scriptName);
-			configure?.Invoke(settings);
-			var args = GetNpmRunArguments(settings);
+        /// <summary>
+        /// execute 'npm run'/'npm run-script' with arguments
+        /// </summary>
+        /// <param name="scriptName">name of the </param>
+        /// <param name="configure"></param>
+        public void RunScript(string scriptName, Action<NpmRunScriptSettings> configure = null)
+        {
+            var settings = new NpmRunScriptSettings(scriptName);
+            configure?.Invoke(settings);
+            var args = GetNpmRunArguments(settings);
 
-			Run(settings, args);
-		}
+            Run(settings, args);
+        }
 
-		private ProcessArgumentBuilder GetNpmRunArguments(NpmRunScriptSettings settings)
-		{
-			var args = new ProcessArgumentBuilder();
-			settings.Evaluate(args);
-			return args;
-		}
+        private ProcessArgumentBuilder GetNpmRunArguments(NpmRunScriptSettings settings)
+        {
+            var args = new ProcessArgumentBuilder();
+            settings.Evaluate(args);
+            return args;
+        }
 
-		/// <summary>
-		/// Gets the name of the tool
-		/// </summary>
-		/// <returns>the name of the tool</returns>
-		protected override string GetToolName()
-		{
-			return "Npm Runner";
-		}
+        /// <summary>
+        /// Gets the name of the tool
+        /// </summary>
+        /// <returns>the name of the tool</returns>
+        protected override string GetToolName()
+        {
+            return "Npm Runner";
+        }
 
-		/// <summary>
-		/// Gets the name of the tool executable
-		/// </summary>
-		/// <returns>The tool executable name</returns>
-		protected override IEnumerable<string> GetToolExecutableNames()
-		{
-			yield return "npm.cmd";
-			yield return "npm";
-		}
-	}
+        /// <summary>
+        /// Gets the name of the tool executable
+        /// </summary>
+        /// <returns>The tool executable name</returns>
+        protected override IEnumerable<string> GetToolExecutableNames()
+        {
+            yield return "npm.cmd";
+            yield return "npm";
+        }
+    }
 }

--- a/src/Cake.Npm/NpmRunner.cs
+++ b/src/Cake.Npm/NpmRunner.cs
@@ -6,60 +6,81 @@ using Cake.Core.Tooling;
 
 namespace Cake.Npm
 {
-    /// <summary>
-    /// A wrapper around the Node Npm package manager
-    /// </summary>
-    public class NpmRunner : Tool<NpmRunnerSettings>
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NpmRunner" /> class.
-        /// </summary>
-        /// <param name="fileSystem">The file system</param>
-        /// <param name="environment">The environment</param>
-        /// <param name="processRunner">The process runner</param>
-        /// <param name="globber">The globber</param>
-        internal NpmRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IGlobber globber) : base(fileSystem, environment, processRunner, globber)
-        {
-        }
-        
-        /// <summary>
-        /// execute 'npm install' with options
-        /// </summary>
-        /// <param name="configure">options when running 'npm install'</param>
-        public void Install(Action<NpmInstallSettings> configure = null)
-        {
-            var settings = new NpmInstallSettings();
-            configure?.Invoke(settings);
+	/// <summary>
+	/// A wrapper around the Node Npm package manager
+	/// </summary>
+	public class NpmRunner : Tool<NpmRunnerSettings>
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="NpmRunner" /> class.
+		/// </summary>
+		/// <param name="fileSystem">The file system</param>
+		/// <param name="environment">The environment</param>
+		/// <param name="processRunner">The process runner</param>
+		/// <param name="globber">The globber</param>
+		internal NpmRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner, IGlobber globber) : base(fileSystem, environment, processRunner, globber)
+		{
+		}
+		
+		/// <summary>
+		/// execute 'npm install' with options
+		/// </summary>
+		/// <param name="configure">options when running 'npm install'</param>
+		public void Install(Action<NpmInstallSettings> configure = null)
+		{
+			var settings = new NpmInstallSettings();
+			configure?.Invoke(settings);
 
-            var args = GetNpmInstallArguments(settings);
+			var args = GetNpmInstallArguments(settings);
 
-            Run(settings, args);
-        }
+			Run(settings, args);
+		}
 
-        private ProcessArgumentBuilder GetNpmInstallArguments(NpmInstallSettings settings)
-        {
-            var args = new ProcessArgumentBuilder();
-            settings.Evaluate(args);
-            return args;
-        }
-        
-        /// <summary>
-        /// Gets the name of the tool
-        /// </summary>
-        /// <returns>the name of the tool</returns>
-        protected override string GetToolName()
-        {
-            return "Npm Runner";
-        }
+		private ProcessArgumentBuilder GetNpmInstallArguments(NpmInstallSettings settings)
+		{
+			var args = new ProcessArgumentBuilder();
+			settings.Evaluate(args);
+			return args;
+		}
 
-        /// <summary>
-        /// Gets the name of the tool executable
-        /// </summary>
-        /// <returns>The tool executable name</returns>
-        protected override IEnumerable<string> GetToolExecutableNames()
-        {
-            yield return "npm.cmd";
-            yield return "npm";
-        }
-    }
+		/// <summary>
+		/// execute 'npm run'/'npm run-script' with arguments
+		/// </summary>
+		/// <param name="scriptName">name of the </param>
+		/// <param name="configure"></param>
+		public void RunScript(string scriptName, Action<NpmRunScriptSettings> configure = null)
+		{
+			var settings = new NpmRunScriptSettings(scriptName);
+			configure?.Invoke(settings);
+			var args = GetNpmRunArguments(settings);
+
+			Run(settings, args);
+		}
+
+		private ProcessArgumentBuilder GetNpmRunArguments(NpmRunScriptSettings settings)
+		{
+			var args = new ProcessArgumentBuilder();
+			settings.Evaluate(args);
+			return args;
+		}
+
+		/// <summary>
+		/// Gets the name of the tool
+		/// </summary>
+		/// <returns>the name of the tool</returns>
+		protected override string GetToolName()
+		{
+			return "Npm Runner";
+		}
+
+		/// <summary>
+		/// Gets the name of the tool executable
+		/// </summary>
+		/// <returns>The tool executable name</returns>
+		protected override IEnumerable<string> GetToolExecutableNames()
+		{
+			yield return "npm.cmd";
+			yield return "npm";
+		}
+	}
 }

--- a/usage.cake
+++ b/usage.cake
@@ -22,6 +22,12 @@ Task("Default")
         
         // npm install --production
         Npm.Install(settings => settings.ForProduction());
+        
+        // npm run hello
+        Npm.RunScript("hello");
+        
+        //npm run arguments -- -debug "arg-value.file"
+        Npm.RunScript("arguments", settings => settings.WithArgument("-debug").WithArgument("arg-value.file"));
     });
         
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This merge enables running `npm run` commands from Cake scripts using a very similar syntax to the existing `Npm.Install()` syntax, with an optional settings object to control script parameters.

As the `usage.cake` updates show, basic scenarios are dead-simple:

```csharp
Npm.RunScript("hello");
```

and the (rarely used) arguments can be appended to scripts with the settings action:

```csharp
//npm run arguments -- -debug "arg-value.file"
Npm.RunScript("arguments", settings => settings.WithArgument("-debug").WithArgument("arg-value.file"));
```

I've included unit tests in the existing project, but I have no idea how your versioning works sorry.

Any feedback welcome.