### PR TITLE
Add initial support for npm pack command

### DIFF
--- a/src/Cake.Npm.Tests/Cake.Npm.Tests.csproj
+++ b/src/Cake.Npm.Tests/Cake.Npm.Tests.csproj
@@ -69,6 +69,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="NpmPackTests.cs" />
     <Compile Include="NpmRunnerFixture.cs" />
     <Compile Include="NpmRunnerTests.cs" />
     <Compile Include="NpmRunScriptTests.cs" />

--- a/src/Cake.Npm.Tests/NpmPackTests.cs
+++ b/src/Cake.Npm.Tests/NpmPackTests.cs
@@ -1,0 +1,29 @@
+﻿using Shouldly;
+using Xunit;
+
+namespace Cake.Npm.Tests
+{
+    public class NpmPackTests
+    {
+        private readonly NpmPackFixture _fixture;
+        public NpmPackTests()
+        {
+            _fixture = new NpmPackFixture();
+        }
+
+        [Fact]
+        public void Not_Setting_Target_Should_Use_Empty()
+        {
+            var result = _fixture.Run();
+            result.Args.ShouldBe("pack");
+        }
+
+        [Fact]
+        public void Including_Target_Should_Set_Correct_Argument()
+        {
+            _fixture.Target = "package.tgz";
+            var result = _fixture.Run();
+            result.Args.ShouldBe("pack package.tgz");
+        }
+    }
+}

--- a/src/Cake.Npm.Tests/NpmRunnerFixture.cs
+++ b/src/Cake.Npm.Tests/NpmRunnerFixture.cs
@@ -47,4 +47,18 @@ namespace Cake.Npm.Tests {
 			tool.RunScript(ScriptName, RunScriptSettings);
 		}
 	}
+
+    public class NpmPackFixture : ToolFixture<NpmPackSettings>
+    {
+        internal string Target { get; set; }
+        public NpmPackFixture() : base("npm")
+        {
+        }
+
+        protected override void RunTool()
+        {
+            var tool = new NpmRunner(FileSystem, Environment, ProcessRunner, Tools);
+            tool.Pack(Target);
+        }
+    }
 }

--- a/src/Cake.Npm/Cake.Npm.csproj
+++ b/src/Cake.Npm/Cake.Npm.csproj
@@ -49,6 +49,7 @@
   <ItemGroup>
     <Compile Include="INpmRunnerCommands.cs" />
     <Compile Include="NpmLogLevel.cs" />
+    <Compile Include="NpmPackSettings.cs" />
     <Compile Include="NpmRunScriptSettings.cs" />
     <Compile Include="..\VersionAssemblyInfo.cs">
       <Link>Properties\VersionAssemblyInfo.cs</Link>

--- a/src/Cake.Npm/NpmPackSettings.cs
+++ b/src/Cake.Npm/NpmPackSettings.cs
@@ -1,0 +1,44 @@
+﻿using Cake.Core;
+using Cake.Core.IO;
+
+namespace Cake.Npm
+{
+    /// <summary>
+    /// npm pack options
+    /// </summary>
+    public class NpmPackSettings : NpmRunnerSettings
+    {
+        /// <summary>
+        /// 'npm pack' settings with target
+        /// </summary>
+        public NpmPackSettings(string target) : base("pack")
+        {
+            Target = target;
+        }
+
+        /// <summary>
+        /// 'npm pack' settings
+        /// </summary>
+        public NpmPackSettings() : this(null)
+        {
+        }
+
+        /// <summary>
+        /// Installation target
+        /// </summary>
+        public string Target { get; set; }
+
+        /// <summary>
+        /// evaluate options
+        /// </summary>
+        /// <param name="args"></param>
+        protected override void EvaluateCore(ProcessArgumentBuilder args)
+        {
+            base.EvaluateCore(args);
+            if (!string.IsNullOrWhiteSpace(Target))
+            {
+                args.Append(Target);
+            }
+        }
+    }
+}

--- a/src/Cake.Npm/NpmRunner.cs
+++ b/src/Cake.Npm/NpmRunner.cs
@@ -168,6 +168,25 @@ namespace Cake.Npm
         }
 
         /// <summary>
+        /// execute 'npm pack' with an optional installable target
+        /// </summary>
+        /// <param name="target">package folder, tarball, or name. Defaults to the current directory</param>
+        public INpmRunnerCommands Pack(string target = null)
+        {
+            var settings = new NpmPackSettings(target);
+            var args = GetNpmPackArguments(settings);
+            Run(settings, args);
+            return this;
+        }
+
+        private ProcessArgumentBuilder GetNpmPackArguments(NpmPackSettings settings)
+        {
+            var args = new ProcessArgumentBuilder();
+            settings?.Evaluate(args);
+            return args;
+        }
+
+        /// <summary>
         /// Gets the name of the tool
         /// </summary>
         /// <returns>the name of the tool</returns>

--- a/src/Cake.Npm/NpmRunnerAliases.cs
+++ b/src/Cake.Npm/NpmRunnerAliases.cs
@@ -111,6 +111,17 @@ namespace Cake.Npm
         /// });
         /// ]]>
         /// </code>
+        /// <para>Run 'npm pack'</para>
+        /// <para>Cake task:</para>
+        /// <code>
+        /// <![CDATA[
+        /// Task("Npm-RunScript")
+        ///     .Does(() =>
+        /// {
+        ///     Npm.Pack();
+        /// });
+        /// ]]>
+        /// </code>
         /// </example>
         [CakePropertyAlias]
         public static NpmRunner Npm(this ICakeContext context)

--- a/usage.cake
+++ b/usage.cake
@@ -26,8 +26,11 @@ Task("Default")
         // npm run hello
         Npm.RunScript("hello");
         
-        //npm run arguments -- -debug "arg-value.file"
+        // npm run arguments -- -debug "arg-value.file"
         Npm.RunScript("arguments", settings => settings.WithArgument("-debug").WithArgument("arg-value.file"));
+
+        // npm pack
+        Npm.Pack();
 
         //npm install gulp.  Executedwith ./usage set as the working directory
         Npm 


### PR DESCRIPTION
Resolves #10 

Adds support for `npm pack`, implemented almost identically to `npm run-script`, but with much simpler settings classes (only one optional argument).

I've also added tests and a fixture for this command.

Let me know if any of it needs work.